### PR TITLE
feat: update subscription status

### DIFF
--- a/composeApp/src/androidDebug/kotlin/io/github/kkoshin/muse/tts/vendor/MockTTSProvider.kt
+++ b/composeApp/src/androidDebug/kotlin/io/github/kkoshin/muse/tts/vendor/MockTTSProvider.kt
@@ -16,7 +16,7 @@ import org.koin.java.KoinJavaComponent.inject
 class MockTTSProvider : TTSProvider {
     private val appContext: Context by inject(Context::class.java)
 
-    override suspend fun queryQuota(): Result<CharacterQuota> = Result.success(CharacterQuota(100, 100))
+    override suspend fun queryQuota(): Result<CharacterQuota> = Result.success(CharacterQuota(100, 100, null))
 
     override suspend fun queryVoices(): Result<List<Voice>> {
         delay(1000)

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/AccountManager.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/AccountManager.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import io.github.kkoshin.elevenlabs.model.SubscriptionStatus
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -15,6 +16,8 @@ class AccountManager(private val context: Context) {
 
     private val key = stringPreferencesKey("elevenLabsApiKey")
 
+    private val statusKey = stringPreferencesKey("subscriptionStatus")
+
     var apiKey: Flow<String?> = context.dataStore.data.map { preferences ->
         preferences[key]
     }
@@ -23,6 +26,18 @@ class AccountManager(private val context: Context) {
         check(apiKey.isNotBlank()) { "api key cannot be blank" }
         context.dataStore.edit { preferences ->
             preferences[key] = apiKey
+        }
+    }
+
+    var subscriptionStatus: Flow<SubscriptionStatus?> = context.dataStore.data.map { preferences ->
+        preferences[statusKey]?.let {
+            SubscriptionStatus.valueOf(it)
+        }
+    }
+
+    suspend fun setSubscriptionStatus(status: SubscriptionStatus) {
+        context.dataStore.edit { preferences ->
+            preferences[statusKey] = status.name
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/App.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/App.kt
@@ -30,7 +30,7 @@ class App : Application() {
     private val appModule = module {
         singleOf(::MuseRepo)
         viewModelOf(::EditorViewModel)
-        viewModel { ExportViewModel(get(), get()) }
+        viewModel { ExportViewModel(get(), get(), get()) }
         viewModel { DashboardViewModel(get()) }
         singleOf(::TTSManager)
         singleOf(::AccountManager)

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/ExportScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/ExportScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.min
 import com.github.foodiestudio.sugar.notification.toast
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
@@ -267,7 +266,7 @@ private fun Content(
                         horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         Text(text = progress.errorMsg, style = MaterialTheme.typography.h6)
-                        Text(text = progress.throwable?.message ?: "", maxLines = 4, overflow = TextOverflow.Ellipsis)
+                        Text(text = progress.throwable?.message ?: "", maxLines = 6, overflow = TextOverflow.Ellipsis)
                     }
                     Button(
                         modifier = Modifier

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/ExportViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/ExportViewModel.kt
@@ -8,15 +8,20 @@ import androidx.lifecycle.viewModelScope
 import com.github.foodiestudio.sugar.ExperimentalSugarApi
 import com.github.foodiestudio.sugar.storage.filesystem.media.MediaFile
 import com.github.foodiestudio.sugar.storage.filesystem.media.MediaStoreType
-import io.github.kkoshin.muse.repo.MuseRepo
+import io.github.kkoshin.elevenlabs.model.SubscriptionStatus
+import io.github.kkoshin.muse.AccountManager
 import io.github.kkoshin.muse.audio.Mp3Decoder
+import io.github.kkoshin.muse.repo.MuseRepo
 import io.github.kkoshin.muse.repo.queryPhrases
 import io.github.kkoshin.muse.tts.TTSManager
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import logcat.asLog
 import logcat.logcat
@@ -29,6 +34,7 @@ import java.util.UUID
 
 class ExportViewModel(
     private val ttsManager: TTSManager,
+    accountManager: AccountManager,
     private val repo: MuseRepo,
 ) : ViewModel() {
     private val appContext: Context by inject(Context::class.java)
@@ -37,7 +43,15 @@ class ExportViewModel(
     private val _progress: MutableStateFlow<ProgressStatus> = MutableStateFlow(ProgressStatus.Idle)
     val progress: StateFlow<ProgressStatus> = _progress.asStateFlow()
 
-    suspend fun queryPhrases(scriptId: String): List<String>? = repo.queryPhrases(UUID.fromString(scriptId))
+    private val maxNumberOfConcurrentRequests = accountManager.subscriptionStatus.map {
+        when (it) {
+            SubscriptionStatus.Active, SubscriptionStatus.Trialing -> Int.MAX_VALUE
+            else -> 4
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, 4)
+
+    suspend fun queryPhrases(scriptId: String): List<String>? =
+        repo.queryPhrases(UUID.fromString(scriptId))
 
     /**
      * 相同的 phrase 仅需要生成一次，最终返回的时候要按照
@@ -49,28 +63,34 @@ class ExportViewModel(
     ) {
         _progress.value = TTSProcessing()
         viewModelScope.launch {
-            val requests = phrases.toSet().map { phrase ->
-                async {
-                    // mp3 原始文件暂时没有记录
-                    ttsManager
-                        .getOrGenerate(voiceId, phrase)
-                        .mapCatching {
-                            saveAsPcm(
-                                phrase,
-                                it,
-                                repo.getPcmCache(voiceId, phrase),
-                            )
-                        }.onFailure {
-                            logcat(tag) {
-                                it.asLog()
+            val uniquePhrases = phrases.toSet()
+            val results = mutableListOf<Result<Unit>>()
+            logcat(tag) { "maxNumberOfConcurrentRequests: ${maxNumberOfConcurrentRequests.value}" }
+            for (batch in uniquePhrases.chunked(maxNumberOfConcurrentRequests.value)) {
+                val requests = batch.map { phrase ->
+                    async {
+                        // mp3 原始文件暂时没有记录
+                        ttsManager
+                            .getOrGenerate(voiceId, phrase)
+                            .mapCatching {
+                                saveAsPcm(
+                                    phrase,
+                                    it,
+                                    repo.getPcmCache(voiceId, phrase),
+                                )
+                            }.onFailure {
+                                logcat(tag) {
+                                    it.asLog()
+                                }
+                                _progress.value =
+                                    TTSFailed(throwable = it)
                             }
-                            _progress.value =
-                                TTSFailed(throwable = it)
-                        }
+                    }
                 }
+                results.addAll(requests.awaitAll())
             }
-            val result = requests.awaitAll()
-            if (result.all { it.isSuccess }) {
+
+            if (results.all { it.isSuccess }) {
                 onSuccess(
                     phrases.map {
                         // 按照 phrases 的顺序返回，前面 tts 这一步是会去重的

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/setting/SettingScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/setting/SettingScreen.kt
@@ -80,6 +80,9 @@ fun SettingScreen(
         accountManager.setElevenLabsApiKey(apiKeyValue!!)
         availableVoiceIds = ttsManager.queryAvailableVoiceIds() ?: emptySet()
         quota = ttsManager.queryQuota().getOrNull()
+        quota?.status?.let {
+            accountManager.setSubscriptionStatus(it)
+        }
     }
 
     Scaffold(

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/TTSProvider.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/TTSProvider.kt
@@ -1,5 +1,6 @@
 package io.github.kkoshin.muse.tts
 
+import io.github.kkoshin.elevenlabs.model.SubscriptionStatus
 import io.github.kkoshin.muse.audio.AudioSampleMetadata
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -34,18 +35,20 @@ data class TTSResult(
 data class CharacterQuota(
     val consumed: Int,
     val total: Int,
+    val status: SubscriptionStatus?,
 ) {
     val remaining: Int
         get() = total - consumed
 
     infix operator fun plus(other: CharacterQuota): CharacterQuota {
         require(consumed >= 0 && total >= 0)
-        return CharacterQuota(consumed + other.consumed, total + other.total)
+        require(status == other.status)
+        return CharacterQuota(consumed + other.consumed, total + other.total, status)
     }
 
     companion object {
-        val unknown = CharacterQuota(-1, -1)
-        val empty = CharacterQuota(0, 0)
+        val unknown = CharacterQuota(-1, -1, null)
+        val empty = CharacterQuota(0, 0, null)
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/vendor/ElevenLabTTSProvider.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/vendor/ElevenLabTTSProvider.kt
@@ -57,6 +57,7 @@ class ElevenLabTTSProvider(
                         CharacterQuota(
                             consumed = it.characterCount,
                             total = it.characterLimit,
+                            status = it.status,
                         )
                     }
                 }


### PR DESCRIPTION
Store subscription status in data store and update it when querying quota. Limit the number of concurrent TTS requests based on the subscription status .