### PR TITLE
feat: add white noise feature

### DIFF
--- a/composeApp/src/androidDebug/kotlin/io/github/kkoshin/muse/tts/vendor/MockSoundEffectProvider.kt
+++ b/composeApp/src/androidDebug/kotlin/io/github/kkoshin/muse/tts/vendor/MockSoundEffectProvider.kt
@@ -1,0 +1,26 @@
+package io.github.kkoshin.muse.tts.vendor
+
+import android.content.Context
+import io.github.kkoshin.muse.debugLog
+import io.github.kkoshin.muse.noise.SoundEffectConfig
+import io.github.kkoshin.muse.noise.SoundEffectProvider
+import kotlinx.coroutines.delay
+import org.koin.java.KoinJavaComponent.inject
+import java.io.OutputStream
+
+class MockSoundEffectProvider : SoundEffectProvider {
+    private val appContext: Context by inject(Context::class.java)
+    override suspend fun makeSoundEffects(
+        prompt: String,
+        config: SoundEffectConfig,
+        target: OutputStream
+    ): Result<Unit> {
+        debugLog { "start makeSoundEffects: $config" }
+        delay(1000)
+        return runCatching {
+            appContext.assets.open("english.mp3").use { inputStream ->
+                inputStream.copyTo(target)
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/App.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/App.kt
@@ -13,6 +13,8 @@ import io.github.kkoshin.muse.editor.EditorViewModel
 import io.github.kkoshin.muse.export.ExportViewModel
 import io.github.kkoshin.muse.isolation.AudioIsolationProvider
 import io.github.kkoshin.muse.isolation.AudioIsolationViewModel
+import io.github.kkoshin.muse.noise.SoundEffectProvider
+import io.github.kkoshin.muse.noise.WhiteNoiseViewModel
 import io.github.kkoshin.muse.repo.MuseRepo
 import io.github.kkoshin.muse.tts.TTSManager
 import io.github.kkoshin.muse.tts.TTSProvider
@@ -36,6 +38,7 @@ class App : Application() {
         viewModel { ExportViewModel(get(), get(), get()) }
         viewModel { DashboardViewModel(get()) }
         viewModel { AudioIsolationViewModel(get()) }
+        viewModel { WhiteNoiseViewModel(get()) }
         singleOf(::TTSManager)
         singleOf(::AccountManager)
         single<CoroutineScope> { MainScope() }
@@ -43,6 +46,9 @@ class App : Application() {
             ElevenLabProvider(get(), get())
         }
         single<AudioIsolationProvider> {
+            ElevenLabProvider(get(), get())
+        }
+        single<SoundEffectProvider> {
             ElevenLabProvider(get(), get())
         }
     }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.unit.dp
@@ -21,6 +22,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterialNavigationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             val bottomSheetNavigator = rememberBottomSheetNavigator()
             val navController = rememberNavController(bottomSheetNavigator)

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/MainScreen.kt
@@ -33,6 +33,8 @@ import io.github.kkoshin.muse.isolation.AudioIsolationPreviewArgs
 import io.github.kkoshin.muse.isolation.AudioIsolationPreviewScreen
 import io.github.kkoshin.muse.isolation.AudioIsolationScreen
 import io.github.kkoshin.muse.navigation.bottomSheet
+import io.github.kkoshin.muse.noise.WhiteNoiseScreen
+import io.github.kkoshin.muse.noise.WhiteNoiseScreenArgs
 import io.github.kkoshin.muse.setting.OpenSourceArgs
 import io.github.kkoshin.muse.setting.OpenSourceScreen
 import io.github.kkoshin.muse.setting.SettingArgs
@@ -96,6 +98,9 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
                             audioUri = uri.toString(),
                         ),
                     )
+                },
+                onLaunchWhiteNoise = {
+                    navController.navigate(WhiteNoiseScreenArgs)
                 }
             )
         }
@@ -200,6 +205,10 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
 
         composable<OpenSourceArgs> {
             OpenSourceScreen()
+        }
+
+        composable<WhiteNoiseScreenArgs> {
+            WhiteNoiseScreen()
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/MainScreen.kt
@@ -33,6 +33,8 @@ import io.github.kkoshin.muse.isolation.AudioIsolationPreviewArgs
 import io.github.kkoshin.muse.isolation.AudioIsolationPreviewScreen
 import io.github.kkoshin.muse.isolation.AudioIsolationScreen
 import io.github.kkoshin.muse.navigation.bottomSheet
+import io.github.kkoshin.muse.noise.WhiteNoiseConfigScreen
+import io.github.kkoshin.muse.noise.WhiteNoiseConfigScreenArgs
 import io.github.kkoshin.muse.noise.WhiteNoiseScreen
 import io.github.kkoshin.muse.noise.WhiteNoiseScreenArgs
 import io.github.kkoshin.muse.setting.OpenSourceArgs
@@ -100,7 +102,7 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
                     )
                 },
                 onLaunchWhiteNoise = {
-                    navController.navigate(WhiteNoiseScreenArgs)
+                    navController.navigate(WhiteNoiseConfigScreenArgs)
                 }
             )
         }
@@ -126,7 +128,7 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
             )
         }
 
-        composable<ScriptCreatorArgs> { entry ->
+        composable<ScriptCreatorArgs> {
             ScriptCreatorScreen(onResult = { scriptId ->
                 navController.popBackStack()
                 navController.currentBackStackEntry
@@ -207,8 +209,19 @@ fun MainScreen(navController: NavHostController = rememberNavController()) {
             OpenSourceScreen()
         }
 
-        composable<WhiteNoiseScreenArgs> {
-            WhiteNoiseScreen()
+        composable<WhiteNoiseConfigScreenArgs> {
+            WhiteNoiseConfigScreen { prompt, config ->
+                navController.navigate(
+                    WhiteNoiseScreenArgs(
+                        prompt,
+                        config.duration?.inWholeMilliseconds,
+                        config.promptInfluence
+                    )
+                )
+            }
+        }
+        composable<WhiteNoiseScreenArgs> { entry ->
+            WhiteNoiseScreen(args = entry.toRoute())
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/dashboard/DashboardScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/dashboard/DashboardScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.Campaign
 import androidx.compose.material.icons.outlined.MusicOff
 import androidx.compose.material.rememberDismissState
 import androidx.compose.runtime.Composable
@@ -105,6 +106,7 @@ fun DashboardScreen(
     onLaunchSettingsPage: () -> Unit,
     onDeepLinkHandled: () -> Unit,
     onLaunchAudioIsolation: (Uri) -> Unit,
+    onLaunchWhiteNoise: () -> Unit,
 ) {
     val scripts by viewModel.scripts.collectAsState()
     val context = LocalContext.current
@@ -228,6 +230,16 @@ fun DashboardScreen(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
+                FloatingActionButton(
+                    modifier = Modifier.size(40.dp),
+                    backgroundColor = MaterialTheme.colors.background,
+                    onClick = {
+                        onLaunchWhiteNoise()
+                    },
+                ) {
+                    Icon(Icons.Outlined.Campaign, contentDescription = null)
+                }
+
                 FloatingActionButton(
                     modifier = Modifier.size(40.dp),
                     backgroundColor = MaterialTheme.colors.background,

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/AudioProcessingView.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/AudioProcessingView.kt
@@ -1,0 +1,197 @@
+package io.github.kkoshin.muse.export
+
+import android.content.Intent
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AudioFile
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.github.foodiestudio.sugar.notification.toast
+import muse.composeapp.generated.resources.Res
+import muse.composeapp.generated.resources.open_with_other_app
+import muse.composeapp.generated.resources.retry
+import muse.composeapp.generated.resources.share_to_other_app
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * 处理音频过程中，成功的话会保存到本地
+ */
+@Composable
+fun AudioProcessingView(
+    modifier: Modifier = Modifier,
+    progress: ProgressStatus,
+    successLabel: String,
+    onRetry: (() -> Unit)? = null
+) {
+    val context = LocalContext.current
+
+    Box(
+        modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        when (progress) {
+            is ProgressStatus.Idle -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(top = 64.dp),
+                    verticalArrangement = Arrangement.spacedBy(64.dp),
+                ) {
+                    CircularProgressIndicator(
+                        Modifier.size(112.dp),
+                        strokeWidth = 6.dp,
+                        strokeCap = StrokeCap.Round,
+                    )
+                }
+            }
+
+            is ProgressStatus.Processing -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(top = 64.dp),
+                    verticalArrangement = Arrangement.spacedBy(64.dp),
+                ) {
+                    CircularProgressIndicator(
+                        Modifier.size(112.dp),
+                        strokeWidth = 6.dp,
+                        strokeCap = StrokeCap.Round,
+                    )
+                    Column(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        AnimatedContent(
+                            targetState = progress.description,
+                            transitionSpec = {
+                                fadeIn()
+                                    .togetherWith(fadeOut())
+                                    .using(
+                                        SizeTransform(clip = false),
+                                    )
+                            },
+                            label = "",
+                        ) {
+                            Text(text = it, style = MaterialTheme.typography.h6)
+                        }
+                    }
+                }
+            }
+
+            is ProgressStatus.Success -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(top = 64.dp),
+                    verticalArrangement = Arrangement.spacedBy(64.dp),
+                ) {
+                    Icon(
+                        Icons.Default.AudioFile,
+                        null,
+                        modifier = Modifier.size(112.dp),
+                        tint = MaterialTheme.colors.onBackground.copy(alpha = 0.5f),
+                    )
+                    Text(
+                        successLabel,
+                        style = MaterialTheme.typography.h6
+                    )
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 60.dp),
+                    ) {
+                        Button(
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = {
+                                Intent(Intent.ACTION_VIEW).let {
+                                    it.data = progress.uri
+                                    context.startActivity(it)
+                                }
+                            },
+                        ) {
+                            Text(text = stringResource(Res.string.open_with_other_app))
+                        }
+
+                        OutlinedButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            onClick = {
+                                runCatching {
+                                    Intent().apply {
+                                        action = Intent.ACTION_SEND
+                                        type = "audio/mpeg"
+                                        putExtra(Intent.EXTRA_STREAM, progress.uri)
+                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                        context.startActivity(this)
+                                    }
+                                }.onFailure { err ->
+                                    context.toast(err.message)
+                                    err.printStackTrace()
+                                }
+                            },
+                        ) {
+                            Text(text = stringResource(Res.string.share_to_other_app))
+                        }
+                    }
+                }
+            }
+
+            is ProgressStatus.Failed -> {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(top = 64.dp),
+                    verticalArrangement = Arrangement.spacedBy(64.dp),
+                ) {
+                    Text("_(:з」∠)_", style = MaterialTheme.typography.h4)
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 32.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(text = progress.errorMsg, style = MaterialTheme.typography.h6)
+                        Text(
+                            text = progress.throwable?.message ?: "",
+                            maxLines = 6,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+
+                    onRetry?.let {
+                        Button(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 60.dp),
+                            onClick = {
+                                it.invoke()
+                            },
+                        ) {
+                            Text(text = stringResource(Res.string.retry))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/ExportScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/export/ExportScreen.kt
@@ -1,34 +1,19 @@
 package io.github.kkoshin.muse.export
 
-import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.material.Button
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -37,13 +22,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.github.foodiestudio.sugar.notification.toast
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 import kotlin.time.Duration.Companion.seconds
@@ -132,8 +112,6 @@ private fun Content(
     progress: ProgressStatus,
     viewModel: ExportViewModel,
 ) {
-    val context = LocalContext.current
-
     LaunchedEffect(voiceId, phrases) {
         if (phrases.isNotEmpty()) {
             viewModel.startTTS(voiceId, phrases) {
@@ -142,156 +120,24 @@ private fun Content(
         }
     }
 
-    Box(
-        modifier.fillMaxSize(),
-        contentAlignment = Alignment.TopCenter,
-    ) {
-        when (progress) {
-            is ProgressStatus.Idle -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    CircularProgressIndicator(
-                        Modifier.size(112.dp),
-                        strokeWidth = 6.dp,
-                        strokeCap = StrokeCap.Round,
-                    )
+    AudioProcessingView(
+        modifier,
+        progress = progress,
+        successLabel = "Export done!",
+        onRetry = {
+            when (progress) {
+                is TTSFailed -> viewModel.startTTS(voiceId, phrases) {
+                    viewModel.mixAudioAsMp3(silence, phrases, it)
                 }
-            }
 
-            is ProgressStatus.Processing -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    CircularProgressIndicator(
-                        Modifier.size(112.dp),
-                        strokeWidth = 6.dp,
-                        strokeCap = StrokeCap.Round,
-                    )
-                    Column(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        AnimatedContent(
-                            targetState = progress.description,
-                            transitionSpec = {
-                                fadeIn()
-                                    .togetherWith(fadeOut())
-                                    .using(
-                                        SizeTransform(clip = false),
-                                    )
-                            },
-                            label = "",
-                        ) {
-                            Text(text = it, style = MaterialTheme.typography.h6)
-                        }
-                        if (phrases.size > 10) {
-                            Text("It may take some time.")
-                        }
-                    }
-                }
-            }
+                is MixFailed -> viewModel.mixAudioAsMp3(
+                    silence,
+                    phrases,
+                    progress.pcmList,
+                )
 
-            is ProgressStatus.Success -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    Icon(
-                        Icons.Default.AudioFile,
-                        null,
-                        modifier = Modifier.size(112.dp),
-                        tint = MaterialTheme.colors.onBackground.copy(alpha = 0.5f),
-                    )
-                    Text("Export done!", style = MaterialTheme.typography.h6)
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 60.dp),
-                    ) {
-                        Button(
-                            modifier = Modifier.fillMaxWidth(),
-                            onClick = {
-                                Intent(Intent.ACTION_VIEW).let {
-                                    it.data = progress.uri
-                                    context.startActivity(it)
-                                }
-                            },
-                        ) {
-                            Text(text = "Open with other app")
-                        }
-
-                        OutlinedButton(
-                            modifier = Modifier.fillMaxWidth(),
-                            onClick = {
-                                runCatching {
-                                    Intent().apply {
-                                        action = Intent.ACTION_SEND
-                                        type = "audio/mpeg"
-                                        putExtra(Intent.EXTRA_STREAM, progress.uri)
-                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                        context.startActivity(this)
-                                    }
-                                }.onFailure { err ->
-                                    context.toast(err.message)
-                                    err.printStackTrace()
-                                }
-                            },
-                        ) {
-                            Text(text = "Share to other app")
-                        }
-                    }
-                }
-            }
-
-            is ProgressStatus.Failed -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    Text("_(:з」∠)_", style = MaterialTheme.typography.h4)
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 32.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(text = progress.errorMsg, style = MaterialTheme.typography.h6)
-                        Text(text = progress.throwable?.message ?: "", maxLines = 6, overflow = TextOverflow.Ellipsis)
-                    }
-                    Button(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 60.dp),
-                        onClick = {
-                            when (progress) {
-                                is TTSFailed -> viewModel.startTTS(voiceId, phrases) {
-                                    viewModel.mixAudioAsMp3(silence, phrases, it)
-                                }
-
-                                is MixFailed -> viewModel.mixAudioAsMp3(
-                                    silence,
-                                    phrases,
-                                    progress.pcmList,
-                                )
-
-                                else -> {}
-                            }
-                        },
-                    ) {
-                        Text(text = "Retry")
-                    }
-                }
+                else -> {}
             }
         }
-    }
+    )
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/isolation/AudioIsolationScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/isolation/AudioIsolationScreen.kt
@@ -1,55 +1,30 @@
 package io.github.kkoshin.muse.isolation
 
-import android.content.Intent
-import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.SizeTransform
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.material.Button
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import com.github.foodiestudio.sugar.notification.toast
-import io.github.kkoshin.muse.export.ProgressStatus
+import io.github.kkoshin.muse.export.AudioProcessingView
 import kotlinx.serialization.Serializable
 import muse.composeapp.generated.resources.Res
 import muse.composeapp.generated.resources.denoise_done
-import muse.composeapp.generated.resources.open_with_other_app
-import muse.composeapp.generated.resources.retry
-import muse.composeapp.generated.resources.share_to_other_app
 import org.jetbrains.compose.resources.stringResource
 import org.koin.androidx.compose.koinViewModel
 
@@ -92,165 +67,16 @@ fun AudioIsolationScreen(
         },
         content = { contentPadding ->
             Box(Modifier.padding(contentPadding)) {
-                Content(
-                    modifier = Modifier.fillMaxSize(),
-                    audioUri = args.audioUri.toUri(),
-                    progress,
-                    viewModel = viewModel,
-                )
+                LaunchedEffect(key1 = Unit) {
+                    viewModel.removeBackgroundNoise(args.audioUri.toUri())
+                }
+
+                AudioProcessingView(
+                    modifier,
+                    progress = progress,
+                    successLabel = stringResource(Res.string.denoise_done),
+                    onRetry = { viewModel.removeBackgroundNoise(args.audioUri.toUri()) })
             }
         },
     )
-}
-
-@Composable
-private fun Content(
-    modifier: Modifier = Modifier,
-    audioUri: Uri,
-    progress: ProgressStatus,
-    viewModel: AudioIsolationViewModel
-) {
-    val context = LocalContext.current
-
-    LaunchedEffect(key1 = Unit) {
-        viewModel.removeBackgroundNoise(audioUri)
-    }
-
-    Box(
-        modifier.fillMaxSize(),
-        contentAlignment = Alignment.TopCenter,
-    ) {
-        when (progress) {
-            is ProgressStatus.Idle -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    CircularProgressIndicator(
-                        Modifier.size(112.dp),
-                        strokeWidth = 6.dp,
-                        strokeCap = StrokeCap.Round,
-                    )
-                }
-            }
-
-            is ProgressStatus.Processing -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    CircularProgressIndicator(
-                        Modifier.size(112.dp),
-                        strokeWidth = 6.dp,
-                        strokeCap = StrokeCap.Round,
-                    )
-                    Column(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        AnimatedContent(
-                            targetState = progress.description,
-                            transitionSpec = {
-                                fadeIn()
-                                    .togetherWith(fadeOut())
-                                    .using(
-                                        SizeTransform(clip = false),
-                                    )
-                            },
-                            label = "",
-                        ) {
-                            Text(text = it, style = MaterialTheme.typography.h6)
-                        }
-                    }
-                }
-            }
-
-            is ProgressStatus.Success -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    Icon(
-                        Icons.Default.AudioFile,
-                        null,
-                        modifier = Modifier.size(112.dp),
-                        tint = MaterialTheme.colors.onBackground.copy(alpha = 0.5f),
-                    )
-                    Text(stringResource(Res.string.denoise_done), style = MaterialTheme.typography.h6)
-                    Column(
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 60.dp),
-                    ) {
-                        Button(
-                            modifier = Modifier.fillMaxWidth(),
-                            onClick = {
-                                Intent(Intent.ACTION_VIEW).let {
-                                    it.data = progress.uri
-                                    context.startActivity(it)
-                                }
-                            },
-                        ) {
-                            Text(text = stringResource(Res.string.open_with_other_app))
-                        }
-
-                        OutlinedButton(
-                            modifier = Modifier.fillMaxWidth(),
-                            onClick = {
-                                runCatching {
-                                    Intent().apply {
-                                        action = Intent.ACTION_SEND
-                                        type = "audio/mpeg"
-                                        putExtra(Intent.EXTRA_STREAM, progress.uri)
-                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                        context.startActivity(this)
-                                    }
-                                }.onFailure { err ->
-                                    context.toast(err.message)
-                                    err.printStackTrace()
-                                }
-                            },
-                        ) {
-                            Text(text = stringResource(Res.string.share_to_other_app))
-                        }
-                    }
-                }
-            }
-
-            is ProgressStatus.Failed -> {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.padding(top = 64.dp),
-                    verticalArrangement = Arrangement.spacedBy(64.dp),
-                ) {
-                    Text("_(:з」∠)_", style = MaterialTheme.typography.h4)
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 32.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        Text(text = progress.errorMsg, style = MaterialTheme.typography.h6)
-                        Text(text = progress.throwable?.message ?: "", maxLines = 6, overflow = TextOverflow.Ellipsis)
-                    }
-                    Button(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 60.dp),
-                        onClick = {
-                            viewModel.removeBackgroundNoise(audioUri)
-                        },
-                    ) {
-                        Text(text = stringResource(Res.string.retry))
-                    }
-                }
-            }
-        }
-    }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/SoundEffectProvider.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/SoundEffectProvider.kt
@@ -1,0 +1,17 @@
+package io.github.kkoshin.muse.noise
+
+import java.io.OutputStream
+import kotlin.time.Duration
+
+interface SoundEffectProvider {
+    suspend fun makeSoundEffects(
+        prompt: String,
+        config: SoundEffectConfig,
+        target: OutputStream
+    ): Result<Unit>
+}
+
+class SoundEffectConfig(
+    val duration: Duration? = null,
+    val promptInfluence: Double = 0.3,
+)

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/SoundEffectProvider.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/SoundEffectProvider.kt
@@ -11,7 +11,7 @@ interface SoundEffectProvider {
     ): Result<Unit>
 }
 
-class SoundEffectConfig(
+data class SoundEffectConfig(
     val duration: Duration? = null,
-    val promptInfluence: Double = 0.3,
+    val promptInfluence: Float = 1f,
 )

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseConfigScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseConfigScreen.kt
@@ -1,0 +1,373 @@
+package io.github.kkoshin.muse.noise
+
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Slider
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.ContentPaste
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material.icons.outlined.AutoFixHigh
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.serialization.Serializable
+import muse.composeapp.generated.resources.Res
+import muse.composeapp.generated.resources.sound_effect
+import muse.composeapp.generated.resources.white_noise_start
+import org.jetbrains.compose.resources.stringResource
+import java.util.Locale
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+enum class ConfigView {
+    None,
+    Duration,
+    PromptInfluence,
+}
+
+@Serializable
+object WhiteNoiseConfigScreenArgs
+
+@Composable
+fun WhiteNoiseConfigScreen(
+    modifier: Modifier = Modifier,
+    onGenerate: (prompt: String, config: SoundEffectConfig) -> Unit
+) {
+    var prompt by remember {
+        mutableStateOf("")
+    }
+
+    var config by remember {
+        mutableStateOf(SoundEffectConfig())
+    }
+
+    var configView by remember {
+        mutableStateOf(ConfigView.None)
+    }
+
+    val backPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+    val clipboardManager = LocalClipboardManager.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        stringResource(Res.string.sound_effect),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.h6
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = {
+                        backPressedDispatcher?.onBackPressed()
+                    }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                windowInsets = WindowInsets.statusBars,
+                backgroundColor = MaterialTheme.colors.surface,
+                elevation = 0.dp,
+            )
+        },
+        content = { paddingValues ->
+            Column(
+                modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colors.onSurface.copy(alpha = 0.12f))
+                    .padding(paddingValues),
+            ) {
+                BasicTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .background(
+                            MaterialTheme.colors.surface,
+                            RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp)
+                        ),
+                    value = prompt,
+                    textStyle = MaterialTheme.typography.h6.copy(color = MaterialTheme.colors.onSurface),
+                    onValueChange = {
+                        prompt = it
+                    },
+                    cursorBrush = SolidColor(MaterialTheme.colors.onBackground),
+                    decorationBox = { field ->
+                        Box(Modifier.padding(16.dp)) {
+                            field()
+                            if (prompt.isEmpty()) {
+                                Column(verticalArrangement = Arrangement.spacedBy(24.dp)) {
+                                    Text(
+                                        "Enter prompt",
+                                        style = MaterialTheme.typography.subtitle1,
+                                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f),
+                                    )
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        OutlinedButton(
+                                            shape = RoundedCornerShape(50),
+                                            onClick = {
+                                                clipboardManager.getText()?.toString()
+                                                    ?.let {
+                                                        prompt = it
+                                                    }
+                                            },
+                                        ) {
+                                            Icon(
+                                                Icons.Default.ContentPaste,
+                                                contentDescription = null,
+                                                modifier = Modifier.size(16.dp),
+                                            )
+                                            Spacer(Modifier.size(8.dp))
+                                            Text("Paste")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                )
+                Column(
+                    Modifier
+                        .navigationBarsPadding()
+                        .padding(vertical = 12.dp)
+                ) {
+                    AnimatedVisibility(
+                        visible = configView != ConfigView.None,
+                        enter = fadeIn() + expandVertically(),
+                        exit = fadeOut() + shrinkVertically()
+                    ) {
+                        when (configView) {
+                            ConfigView.Duration -> {
+                                DurationConfig(
+                                    modifier = Modifier,
+                                    duration = config.duration
+                                ) { config = config.copy(duration = it) }
+                            }
+
+                            ConfigView.PromptInfluence -> {
+                                PromptInfluenceConfig(
+                                    modifier = Modifier,
+                                    config.promptInfluence
+                                ) { config = config.copy(promptInfluence = it) }
+                            }
+
+                            else -> {}
+                        }
+                    }
+                    Row(
+                        Modifier
+                            .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        ConfigMenuButton(
+                            selected = configView == ConfigView.Duration,
+                            Icons.Default.AccessTime,
+                            config.duration.format(),
+                            onClick = {
+                                configView = if (configView == ConfigView.Duration) {
+                                    ConfigView.None
+                                } else {
+                                    ConfigView.Duration
+                                }
+                            }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        ConfigMenuButton(
+                            selected = configView == ConfigView.PromptInfluence,
+                            Icons.Default.Lightbulb,
+                            String.format(Locale.getDefault(), "%.2f", config.promptInfluence),
+                            onClick = {
+                                configView = if (configView == ConfigView.PromptInfluence) {
+                                    ConfigView.None
+                                } else {
+                                    ConfigView.PromptInfluence
+                                }
+                            }
+                        )
+                        Spacer(Modifier.weight(1f))
+                        Button(
+                            enabled = prompt.isNotBlank(),
+                            shape = RoundedCornerShape(50),
+                            onClick = {
+                                onGenerate(prompt, config)
+                            },
+                            colors = ButtonDefaults.buttonColors(
+                                disabledBackgroundColor = MaterialTheme.colors.primary.copy(alpha = 0.12f)
+                            ),
+                        ) {
+                            Icon(
+                                Icons.Outlined.AutoFixHigh,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                            )
+                            Spacer(Modifier.size(8.dp))
+                            Text(stringResource(Res.string.white_noise_start))
+                        }
+                    }
+                }
+            }
+        }
+    )
+}
+
+private fun Duration?.format(): String {
+    if (this == null) return "Auto"
+    return String.format(Locale.getDefault(), "%.2fs", this.inWholeMilliseconds / 1000.0)
+}
+
+@Composable
+private fun ConfigMenuButton(
+    selected: Boolean,
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit
+) {
+    IconButton(onClick = {
+        onClick()
+    }) {
+        val color = if (selected) MaterialTheme.colors.primary else MaterialTheme.colors.onSurface
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(
+                icon,
+                contentDescription = null,
+                tint = color.copy(alpha = 0.7f)
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.caption,
+                color = color.copy(alpha = 0.7f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun DurationConfig(
+    modifier: Modifier,
+    duration: Duration?,
+    onDurationChange: (Duration?) -> Unit
+) {
+
+    var number by remember {
+        mutableDoubleStateOf(
+            duration?.inWholeMilliseconds?.div(1000.0) ?: 10.0
+        )
+    }
+
+    Column(modifier.padding(horizontal = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            "Duration",
+            Modifier.padding(horizontal = 8.dp),
+            style = MaterialTheme.typography.subtitle1
+        )
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Switch(
+                checked = duration == null,
+                onCheckedChange = { checked ->
+                    onDurationChange(if (checked) null else number.seconds)
+                },
+                colors = SwitchDefaults.colors(checkedThumbColor = MaterialTheme.colors.primary),
+            )
+            Text("Automatically pick the best duration", style = MaterialTheme.typography.body2)
+        }
+        Box {
+            Row(Modifier.padding(horizontal = 8.dp)) {
+                Text("0.5s", style = MaterialTheme.typography.overline)
+                Spacer(Modifier.weight(1f))
+                Text("22s", style = MaterialTheme.typography.overline)
+            }
+            Slider(
+                enabled = duration != null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
+                value = number.toFloat(),
+                onValueChange = {
+                    number = it.toDouble()
+                    onDurationChange(number.seconds)
+                },
+                valueRange = 0.5f..22.0f
+            )
+        }
+    }
+}
+
+@Composable
+private fun PromptInfluenceConfig(
+    modifier: Modifier,
+    influence: Float,
+    onInfluenceChange: (Float) -> Unit
+) {
+    Column(modifier.padding(horizontal = 8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            "Prompt Influence",
+            Modifier.padding(horizontal = 8.dp),
+            style = MaterialTheme.typography.subtitle1
+        )
+        Text(
+            modifier = Modifier.padding(horizontal = 8.dp),
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.6f),
+            text = "Slide the scale to make your generation perfectly adhere to your prompt or allow for a little creativity.",
+        )
+        Box {
+            Row(Modifier.padding(horizontal = 8.dp)) {
+                Text("More creative", style = MaterialTheme.typography.overline)
+                Spacer(Modifier.weight(1f))
+                Text("Follow Prompt", style = MaterialTheme.typography.overline)
+            }
+            Slider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
+                value = influence,
+                onValueChange = onInfluenceChange,
+                valueRange = 0.0f..1.0f,
+            )
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseScreen.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseScreen.kt
@@ -1,0 +1,102 @@
+package io.github.kkoshin.muse.noise
+
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AutoFixHigh
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.serialization.Serializable
+import org.koin.androidx.compose.koinViewModel
+
+@Serializable
+object WhiteNoiseScreenArgs
+
+@Composable
+fun WhiteNoiseScreen(
+    modifier: Modifier = Modifier,
+    viewModel: WhiteNoiseViewModel = koinViewModel(),
+) {
+    val backPressedDispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+
+    var prompt by remember {
+        mutableStateOf("")
+    }
+
+    Scaffold(
+        modifier = modifier,
+        contentWindowInsets = WindowInsets.systemBars,
+        topBar = {
+            TopAppBar(
+                windowInsets = WindowInsets.statusBars,
+                backgroundColor = MaterialTheme.colors.surface,
+                navigationIcon = {
+                    IconButton(onClick = {
+                        backPressedDispatcher?.onBackPressed()
+                    }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                title = {
+                    Text(text = "White Noise")
+                },
+            )
+        },
+        content = { paddingValues ->
+            Column(Modifier.padding(paddingValues)) {
+                // TODO: Update UI
+                TextField(
+                    value = prompt,
+                    onValueChange = {
+                        prompt = it
+                    },
+                    label = { Text(text = "Prompt") },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                backgroundColor = MaterialTheme.colors.primary,
+                shape = RoundedCornerShape(16.dp),
+                onClick = {
+                    if (prompt.isNotEmpty()) {
+                        viewModel.generate(prompt)
+                    }
+                },
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                ) {
+                    Icon(Icons.Filled.AutoFixHigh, contentDescription = null)
+                    Text("Generate")
+                }
+            }
+        }
+    )
+}

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseViewModel.kt
@@ -2,29 +2,37 @@ package io.github.kkoshin.muse.noise
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.github.kkoshin.muse.export.ProgressStatus
 import io.github.kkoshin.muse.tts.TTSManager
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import logcat.logcat
 
 class WhiteNoiseViewModel(
     private val ttsManager: TTSManager,
 ) : ViewModel() {
-    // TODO: show progress
-    fun generate(prompt: String) {
-        viewModelScope.launch {
+
+    private val _progress: MutableStateFlow<ProgressStatus> = MutableStateFlow(ProgressStatus.Idle)
+    val progress: StateFlow<ProgressStatus> = _progress.asStateFlow()
+
+    private var lastJob: Job? = null
+
+    fun generate(prompt: String, config: SoundEffectConfig) {
+        _progress.value = ProgressStatus.Processing("remove background noise")
+        lastJob?.cancel()
+        lastJob = viewModelScope.launch {
             ttsManager.makeSoundEffects(
                 prompt,
-                config = SoundEffectConfig(promptInfluence = 0.5)
-            ).onSuccess {
-                logcat {
-                    "generate success."
-                }
-            }.onFailure {
-                it.printStackTrace()
-                logcat {
-                    "generate fail. "
-                }
-            }
+                config = config
+            ).fold(
+                onSuccess = {
+                    _progress.value = ProgressStatus.Success(it)
+                },
+                onFailure = {
+                    _progress.value = ProgressStatus.Failed(it.message ?: "unknown", it)
+                })
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/noise/WhiteNoiseViewModel.kt
@@ -1,0 +1,30 @@
+package io.github.kkoshin.muse.noise
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.kkoshin.muse.tts.TTSManager
+import kotlinx.coroutines.launch
+import logcat.logcat
+
+class WhiteNoiseViewModel(
+    private val ttsManager: TTSManager,
+) : ViewModel() {
+    // TODO: show progress
+    fun generate(prompt: String) {
+        viewModelScope.launch {
+            ttsManager.makeSoundEffects(
+                prompt,
+                config = SoundEffectConfig(promptInfluence = 0.5)
+            ).onSuccess {
+                logcat {
+                    "generate success."
+                }
+            }.onFailure {
+                it.printStackTrace()
+                logcat {
+                    "generate fail. "
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/TTSManager.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/TTSManager.kt
@@ -133,7 +133,7 @@ class TTSManager(
         prompt: String,
         config: SoundEffectConfig,
         fileNameWithoutExtension: String = "Sound_${Instant.now().epochSecond}",
-    ): Result<Unit> {
+    ): Result<Uri> {
         val targetUri = MediaFile
             .create(
                 appContext,
@@ -150,6 +150,7 @@ class TTSManager(
                     outputStream,
                 )
             }
+            Result.success(targetUri)
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/TTSManager.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/TTSManager.kt
@@ -17,16 +17,21 @@ import com.github.foodiestudio.sugar.storage.filesystem.media.MediaStoreType
 import com.github.foodiestudio.sugar.storage.filesystem.toOkioPath
 import io.github.kkoshin.muse.R
 import io.github.kkoshin.muse.isolation.AudioIsolationProvider
+import io.github.kkoshin.muse.noise.SoundEffectConfig
+import io.github.kkoshin.muse.noise.SoundEffectProvider
+import io.github.kkoshin.muse.repo.MuseRepo
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import okio.source
+import java.time.Instant
 
 @OptIn(ExperimentalSugarApi::class)
 class TTSManager(
     private val appContext: Context,
     private val provider: TTSProvider,
     private val isolationProvider: AudioIsolationProvider,
+    private val soundEffectProvider: SoundEffectProvider,
 ) {
     /**
      * 持久化 text:Uri
@@ -121,6 +126,30 @@ class TTSManager(
                 fileSystem.source(audioUri.toOkioPath()),
                 name
             )
+        }
+    }
+
+    suspend fun makeSoundEffects(
+        prompt: String,
+        config: SoundEffectConfig,
+        fileNameWithoutExtension: String = "Sound_${Instant.now().epochSecond}",
+    ): Result<Unit> {
+        val targetUri = MediaFile
+            .create(
+                appContext,
+                MediaStoreType.Downloads,
+                "$fileNameWithoutExtension.mp3",
+                MuseRepo.getExportRelativePath(appContext),
+                enablePending = false,
+            ).mediaUri
+        return withContext(Dispatchers.IO) {
+            appContext.contentResolver.openOutputStream(targetUri)!!.use { outputStream ->
+                soundEffectProvider.makeSoundEffects(
+                    prompt,
+                    config,
+                    outputStream,
+                )
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/vendor/ElevenLabProvider.kt
+++ b/composeApp/src/androidMain/kotlin/io/github/kkoshin/muse/tts/vendor/ElevenLabProvider.kt
@@ -3,6 +3,7 @@ package io.github.kkoshin.muse.tts.vendor
 import io.github.kkoshin.elevenlabs.ElevenLabsClient
 import io.github.kkoshin.elevenlabs.api.getSubscription
 import io.github.kkoshin.elevenlabs.api.getVoices
+import io.github.kkoshin.elevenlabs.api.makeSoundEffects
 import io.github.kkoshin.elevenlabs.api.textToSpeech
 import io.github.kkoshin.elevenlabs.model.FreeTierOutputFormat
 import io.github.kkoshin.elevenlabs.model.ModelId
@@ -10,6 +11,8 @@ import io.github.kkoshin.elevenlabs.model.TextToSpeechRequest
 import io.github.kkoshin.muse.AccountManager
 import io.github.kkoshin.muse.audio.MonoAudioSampleMetadata
 import io.github.kkoshin.muse.isolation.AudioIsolationProvider
+import io.github.kkoshin.muse.noise.SoundEffectConfig
+import io.github.kkoshin.muse.noise.SoundEffectProvider
 import io.github.kkoshin.muse.tts.CharacterQuota
 import io.github.kkoshin.muse.tts.SupportedAudioType
 import io.github.kkoshin.muse.tts.TTSProvider
@@ -27,11 +30,12 @@ import kotlinx.coroutines.withContext
 import logcat.logcat
 import okio.Source
 import removeBackgroundAudio
+import java.io.OutputStream
 
 class ElevenLabProvider(
     private val accountManager: AccountManager,
     private val scope: CoroutineScope,
-) : TTSProvider, AudioIsolationProvider {
+) : TTSProvider, AudioIsolationProvider, SoundEffectProvider {
     private lateinit var client: ElevenLabsClient
 
     @Volatile
@@ -147,6 +151,23 @@ class ElevenLabProvider(
         return withContext(Dispatchers.IO) {
             requireClient().mapCatching { client ->
                 client.removeBackgroundAudio(audio, audioName).getOrThrow()
+            }
+        }
+    }
+
+    override suspend fun makeSoundEffects(
+        prompt: String,
+        config: SoundEffectConfig,
+        target: OutputStream,
+    ): Result<Unit> {
+        return withContext(Dispatchers.IO) {
+            requireClient().mapCatching { client ->
+                client.makeSoundEffects(
+                    prompt,
+                    durationSeconds = config.duration?.inWholeMilliseconds?.let { it / 1000.0 },
+                    promptInfluence = config.promptInfluence,
+                    outputStream = target,
+                ).getOrThrow()
             }
         }
     }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -6,11 +6,14 @@
     <string name="projects">Projects</string>
     <string name="remove_noise">Remove noise</string>
     <string name="audio_isolation">Audio Isolation</string>
+    <string name="sound_effect">Sound Effect</string>
     <string name="retry">Retry</string>
     <string name="share_to_other_app">Share to other app</string>
     <string name="open_with_other_app">Open with other app</string>
     <string name="export_done">Export done!</string>
     <string name="denoise_done">Denoise done!</string>
+    <string name="generate_done">Generate done!</string>
     <string name="audio_isolation_error_audio_file_too_large">Audio files must be under 500 MB or 1 hour in length. Files exceeding these limits cannot be processed.</string>
     <string name="audio_isolation_error_audio_file_too_short">Please ensure your audio file is at least 4.6 seconds long. Shorter files cannot be processed.</string>
+    <string name="white_noise_start">Generate</string>
 </resources>

--- a/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/api/SoundGeneration.kt
+++ b/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/api/SoundGeneration.kt
@@ -13,7 +13,7 @@ class SoundGeneration
 suspend fun ElevenLabsClient.makeSoundEffects(
     prompt: String,
     durationSeconds: Double?,
-    promptInfluence: Double,
+    promptInfluence: Float,
     outputStream: OutputStream
 ): Result<Unit> =
     post<SoundGenerationRequest, SoundGeneration, ByteReadChannel>(

--- a/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/api/SoundGeneration.kt
+++ b/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/api/SoundGeneration.kt
@@ -1,0 +1,27 @@
+package io.github.kkoshin.elevenlabs.api
+
+import io.github.kkoshin.elevenlabs.ElevenLabsClient
+import io.github.kkoshin.elevenlabs.model.SoundGenerationRequest
+import io.ktor.resources.Resource
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.jvm.javaio.copyTo
+import java.io.OutputStream
+
+@Resource("/sound-generation")
+class SoundGeneration
+
+suspend fun ElevenLabsClient.makeSoundEffects(
+    prompt: String,
+    durationSeconds: Double?,
+    promptInfluence: Double,
+    outputStream: OutputStream
+): Result<Unit> =
+    post<SoundGenerationRequest, SoundGeneration, ByteReadChannel>(
+        SoundGeneration(), data = SoundGenerationRequest(
+            text = prompt,
+            durationSeconds = durationSeconds,
+            promptInfluence = promptInfluence,
+        )
+    ).mapCatching {
+        it.copyTo(outputStream)
+    }

--- a/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/model/SoundGenerationRequest.kt
+++ b/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/model/SoundGenerationRequest.kt
@@ -12,7 +12,7 @@ data class SoundGenerationRequest(
 
     // [0.0, 1.0]
     @SerialName("prompt_influence")
-    val promptInfluence: Double = 0.3,
+    val promptInfluence: Float = 0.3f,
 ) {
     init {
         require(durationSeconds == null || durationSeconds in 0.5..22.0) { "duration_seconds must be in [0.5, 22.0]" }

--- a/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/model/SoundGenerationRequest.kt
+++ b/elevenlabs/src/commonMain/kotlin/io/github/kkoshin/elevenlabs/model/SoundGenerationRequest.kt
@@ -1,0 +1,21 @@
+package io.github.kkoshin.elevenlabs.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SoundGenerationRequest(
+    val text: String,
+    // [0.5, 22.0], if not specified, will guess based on text length
+    @SerialName("duration_seconds")
+    val durationSeconds: Double? = null,
+
+    // [0.0, 1.0]
+    @SerialName("prompt_influence")
+    val promptInfluence: Double = 0.3,
+) {
+    init {
+        require(durationSeconds == null || durationSeconds in 0.5..22.0) { "duration_seconds must be in [0.5, 22.0]" }
+        require(promptInfluence in 0.0..1.0) { "prompt_influence must be in [0.0, 1.0]" }
+    }
+}


### PR DESCRIPTION
- Add a white noise screen and its associated navigation.
- Implement sound effect generation using ElevenLabs API.
- Add a button to the dashboard to launch the white noise screen.
- Implement `SoundEffectProvider` interface and `SoundEffectConfig` to control the sound generation.
- Add mock `SoundEffectProvider` for debug builds.
- Update dependencies for `elevenlabs` module.