### PR TITLE
feat: add API key configuration guide flow

### DIFF
--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/MainScreen.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/MainScreen.kt
@@ -36,6 +36,8 @@ import io.github.kkoshin.muse.feature.noise.WhiteNoiseConfigScreen
 import io.github.kkoshin.muse.feature.noise.WhiteNoiseConfigScreenArgs
 import io.github.kkoshin.muse.feature.noise.WhiteNoiseScreen
 import io.github.kkoshin.muse.feature.noise.WhiteNoiseScreenArgs
+import io.github.kkoshin.muse.feature.setting.ApiKeyHelpArgs
+import io.github.kkoshin.muse.feature.setting.ApiKeyHelpScreen
 import io.github.kkoshin.muse.feature.setting.OpenSourceArgs
 import io.github.kkoshin.muse.feature.setting.OpenSourceScreen
 import io.github.kkoshin.muse.feature.setting.SettingArgs
@@ -81,6 +83,7 @@ private val navConfig = SavedStateConfiguration {
             subclass(WhiteNoiseScreenArgs::class, WhiteNoiseScreenArgs.serializer())
             subclass(AudioIsolationPreviewArgs::class, AudioIsolationPreviewArgs.serializer())
             subclass(AudioIsolationArgs::class, AudioIsolationArgs.serializer())
+            subclass(ApiKeyHelpArgs::class, ApiKeyHelpArgs.serializer())
         }
     }
 }
@@ -111,7 +114,7 @@ fun MainScreen() {
                         },
                         onLaunchSettingsPage = {
                             if (backStack.none { it is SettingArgs }) {
-                                backStack.add(SettingArgs)
+                                backStack.add(SettingArgs())
                             }
                         },
                         onLaunchAudioIsolation = { path ->
@@ -143,6 +146,12 @@ fun MainScreen() {
                         onPickVoice = {
                             backStack.add(VoicePickerArgs(emptyList()))
                         },
+                        onNavigateToSettings = {
+                            backStack.add(SettingArgs(scrollToApiKey = true))
+                        },
+                        onNavigateToApiKeyHelp = {
+                            backStack.add(ApiKeyHelpArgs)
+                        },
                     )
                 }
 
@@ -170,6 +179,7 @@ fun MainScreen() {
 
                 is SettingArgs -> NavEntry(key) {
                     SettingScreen(
+                        args = key,
                         versionName = platformInfo.versionName,
                         versionCode = platformInfo.versionCode,
                         folderPath = platformInfo.exportFolderPath,
@@ -185,20 +195,37 @@ fun MainScreen() {
                     )
                 }
 
+                is ApiKeyHelpArgs -> NavEntry(key) {
+                    ApiKeyHelpScreen(
+                        onGoToSettings = {
+                            backStack.add(SettingArgs(scrollToApiKey = true))
+                        },
+                        onOpenURL = { platformInfo.onOpenURL(it) },
+                    )
+                }
+
                 is OpenSourceArgs -> NavEntry(key) {
                     OpenSourceScreen(onOpenURL = { platformInfo.onOpenURL(it) })
                 }
 
                 is WhiteNoiseConfigScreenArgs -> NavEntry(key) {
-                    WhiteNoiseConfigScreen { prompt, config ->
-                        backStack.add(
-                            WhiteNoiseScreenArgs(
-                                prompt,
-                                config.duration?.inWholeMilliseconds,
-                                config.promptInfluence,
-                            ),
-                        )
-                    }
+                    WhiteNoiseConfigScreen(
+                        onGenerate = { prompt, config ->
+                            backStack.add(
+                                WhiteNoiseScreenArgs(
+                                    prompt,
+                                    config.duration?.inWholeMilliseconds,
+                                    config.promptInfluence,
+                                ),
+                            )
+                        },
+                        onNavigateToSettings = {
+                            backStack.add(SettingArgs(scrollToApiKey = true))
+                        },
+                        onNavigateToApiKeyHelp = {
+                            backStack.add(ApiKeyHelpArgs)
+                        },
+                    )
                 }
 
                 is WhiteNoiseScreenArgs -> NavEntry(key) {
@@ -241,9 +268,16 @@ fun MainScreen() {
                 }
 
                 is AudioIsolationArgs -> NavEntry(key) {
-                    AudioIsolationScreen(args = key) {
-                        backStack.removeLastOrNull()
-                    }
+                    AudioIsolationScreen(
+                        args = key,
+                        onDone = { backStack.removeLastOrNull() },
+                        onNavigateToSettings = {
+                            backStack.add(SettingArgs(scrollToApiKey = true))
+                        },
+                        onNavigateToApiKeyHelp = {
+                            backStack.add(ApiKeyHelpArgs)
+                        },
+                    )
                 }
 
                 else -> error("Unknown route: $key")

--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/core/manager/AccountManager.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/core/manager/AccountManager.kt
@@ -18,6 +18,10 @@ class AccountManager(private val dataStore: DataStore<Preferences>) {
         preferences[key]
     }
 
+    val apiKeyConfigured: Flow<Boolean> = dataStore.data.map { preferences ->
+        !preferences[key].isNullOrEmpty()
+    }
+
     suspend fun setElevenLabsApiKey(apiKey: String) {
         check(apiKey.isNotBlank()) { "api key cannot be blank" }
         dataStore.edit { preferences ->

--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/editor/EditorScreen.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/editor/EditorScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,13 +37,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import io.github.kkoshin.muse.core.manager.AccountManager
 import io.github.kkoshin.muse.core.provider.Voice
 import io.github.kkoshin.muse.editor.ExportModeTabRow
+import io.github.kkoshin.muse.feature.setting.ApiKeyRequiredSheet
 import io.github.kkoshin.muse.platformbridge.AppBackButton
 import io.github.kkoshin.muse.platformbridge.LocalToaster
 import kotlinx.coroutines.launch
 import io.github.kkoshin.muse.Route
 import kotlinx.serialization.Serializable
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Serializable
@@ -62,12 +66,18 @@ fun EditorScreen(
     viewModel: EditorViewModel = koinViewModel(),
     onExportRequest: (List<Voice>, ExportMode) -> Unit,
     onPickVoice: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onNavigateToApiKeyHelp: () -> Unit,
 ) {
     val localToaster = LocalToaster.current
+    val accountManager = koinInject<AccountManager>()
+    val apiKeyConfigured by accountManager.apiKeyConfigured.collectAsState(false)
 
     var loadingVisible by remember {
         mutableStateOf(false)
     }
+
+    var showApiKeyDialog by remember { mutableStateOf(false) }
 
     val scope = rememberCoroutineScope()
 
@@ -152,20 +162,24 @@ fun EditorScreen(
                     backgroundColor = MaterialTheme.colors.primary,
                     shape = RoundedCornerShape(16.dp),
                     onClick = {
-                        scope.launch {
-                            loadingVisible = true
-                            viewModel
-                                .fetchAvailableVoices()
-                                .onSuccess {
-                                    if (it.isEmpty()) {
-                                        onPickVoice()
-                                    } else {
-                                        onExportRequest(it, selectedMode)
+                        if (!apiKeyConfigured) {
+                            showApiKeyDialog = true
+                        } else {
+                            scope.launch {
+                                loadingVisible = true
+                                viewModel
+                                    .fetchAvailableVoices()
+                                    .onSuccess {
+                                        if (it.isEmpty()) {
+                                            onPickVoice()
+                                        } else {
+                                            onExportRequest(it, selectedMode)
+                                        }
+                                    }.onFailure { e ->
+                                        localToaster.show(e.message)
                                     }
-                                }.onFailure { e ->
-                                    localToaster.show(e.message)
-                                }
-                            loadingVisible = false
+                                loadingVisible = false
+                            }
                         }
                     },
                 ) {
@@ -181,4 +195,18 @@ fun EditorScreen(
             }
         },
     )
+
+    if (showApiKeyDialog) {
+        ApiKeyRequiredSheet(
+            onGoToSettings = {
+                showApiKeyDialog = false
+                onNavigateToSettings()
+            },
+            onWhatIsApiKey = {
+                showApiKeyDialog = false
+                onNavigateToApiKeyHelp()
+            },
+            onDismiss = { showApiKeyDialog = false },
+        )
+    }
 }

--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/isolation/AudioIsolationScreen.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/isolation/AudioIsolationScreen.kt
@@ -16,9 +16,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import io.github.kkoshin.muse.core.manager.AccountManager
 import io.github.kkoshin.muse.feature.export.AudioProcessingView
+import io.github.kkoshin.muse.feature.setting.ApiKeyRequiredSheet
 import io.github.kkoshin.muse.platformbridge.BackHandler
 import kotlinx.serialization.Serializable
 import museroot.muse.generated.resources.Res
@@ -26,6 +31,7 @@ import museroot.muse.generated.resources.denoise_done
 import io.github.kkoshin.muse.Route
 import okio.Path.Companion.toPath
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Serializable
@@ -38,12 +44,25 @@ fun AudioIsolationScreen(
     modifier: Modifier = Modifier,
     args: AudioIsolationArgs,
     viewModel: AudioIsolationViewModel = koinViewModel(),
-    onExit: () -> Unit,
+    onDone: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onNavigateToApiKeyHelp: () -> Unit,
 ) {
+    val accountManager = koinInject<AccountManager>()
+    val apiKeyConfigured by accountManager.apiKeyConfigured.collectAsState(false)
     val progress by viewModel.progress.collectAsState()
+    var showApiKeyDialog by remember { mutableStateOf(false) }
 
     BackHandler {
-        onExit()
+        onDone()
+    }
+
+    LaunchedEffect(apiKeyConfigured) {
+        if (apiKeyConfigured) {
+            viewModel.removeBackgroundNoise(args.audioUri.toPath())
+        } else {
+            showApiKeyDialog = true
+        }
     }
 
     Scaffold(
@@ -54,7 +73,7 @@ fun AudioIsolationScreen(
                 title = {},
                 navigationIcon = {
                     IconButton(onClick = {
-                        onExit()
+                        onDone()
                     }) {
                         Icon(Icons.Filled.Close, contentDescription = null)
                     }
@@ -66,10 +85,6 @@ fun AudioIsolationScreen(
         },
         content = { contentPadding ->
             Box(Modifier.padding(contentPadding)) {
-                LaunchedEffect(key1 = Unit) {
-                    viewModel.removeBackgroundNoise(args.audioUri.toPath())
-                }
-
                 AudioProcessingView(
                     modifier,
                     progress = progress,
@@ -78,4 +93,21 @@ fun AudioIsolationScreen(
             }
         },
     )
+
+    if (showApiKeyDialog) {
+        ApiKeyRequiredSheet(
+            onGoToSettings = {
+                showApiKeyDialog = false
+                onNavigateToSettings()
+            },
+            onWhatIsApiKey = {
+                showApiKeyDialog = false
+                onNavigateToApiKeyHelp()
+            },
+            onDismiss = {
+                showApiKeyDialog = false
+                onDone()
+            },
+        )
+    }
 }

--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/noise/WhiteNoiseConfigScreen.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/noise/WhiteNoiseConfigScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.outlined.AutoFixHigh
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -51,11 +52,14 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import io.github.kkoshin.muse.core.manager.AccountManager
 import io.github.kkoshin.muse.core.provider.SoundEffectConfig
 import io.github.kkoshin.muse.feature.editor.formatDecimal
+import io.github.kkoshin.muse.feature.setting.ApiKeyRequiredSheet
 import io.github.kkoshin.muse.platformbridge.AppBackButton
 import io.github.kkoshin.muse.Route
 import kotlinx.serialization.Serializable
+import org.koin.compose.koinInject
 import museroot.muse.generated.resources.Res
 import museroot.muse.generated.resources.sound_effect
 import museroot.muse.generated.resources.white_noise_start
@@ -75,8 +79,13 @@ object WhiteNoiseConfigScreenArgs : Route
 @Composable
 fun WhiteNoiseConfigScreen(
     modifier: Modifier = Modifier,
-    onGenerate: (prompt: String, config: SoundEffectConfig) -> Unit
+    onGenerate: (prompt: String, config: SoundEffectConfig) -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onNavigateToApiKeyHelp: () -> Unit,
 ) {
+    val accountManager = koinInject<AccountManager>()
+    val apiKeyConfigured by accountManager.apiKeyConfigured.collectAsState(false)
+
     var prompt by remember {
         mutableStateOf("")
     }
@@ -88,6 +97,8 @@ fun WhiteNoiseConfigScreen(
     var configView by remember {
         mutableStateOf(ConfigView.None)
     }
+
+    var showApiKeyDialog by remember { mutableStateOf(false) }
 
     val clipboardManager = LocalClipboardManager.current
 
@@ -230,7 +241,11 @@ fun WhiteNoiseConfigScreen(
                             enabled = prompt.isNotBlank(),
                             shape = RoundedCornerShape(50),
                             onClick = {
-                                onGenerate(prompt, config)
+                                if (!apiKeyConfigured) {
+                                    showApiKeyDialog = true
+                                } else {
+                                    onGenerate(prompt, config)
+                                }
                             },
                             colors = ButtonDefaults.buttonColors(
                                 disabledBackgroundColor = MaterialTheme.colors.primary.copy(alpha = 0.12f)
@@ -249,6 +264,20 @@ fun WhiteNoiseConfigScreen(
             }
         }
     )
+
+    if (showApiKeyDialog) {
+        ApiKeyRequiredSheet(
+            onGoToSettings = {
+                showApiKeyDialog = false
+                onNavigateToSettings()
+            },
+            onWhatIsApiKey = {
+                showApiKeyDialog = false
+                onNavigateToApiKeyHelp()
+            },
+            onDismiss = { showApiKeyDialog = false },
+        )
+    }
 }
 
 private fun Duration?.format(): String {

--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/setting/ApiKeyHelpScreen.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/setting/ApiKeyHelpScreen.kt
@@ -1,0 +1,367 @@
+package io.github.kkoshin.muse.feature.setting
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material.icons.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import io.github.kkoshin.muse.Route
+import io.github.kkoshin.muse.platformbridge.AppBackButton
+import kotlinx.serialization.Serializable
+
+private val cardShape = RoundedCornerShape(12.dp)
+
+@Serializable
+object ApiKeyHelpArgs : Route
+
+@Composable
+fun ApiKeyHelpScreen(
+    onGoToSettings: () -> Unit,
+    onOpenURL: (String) -> Unit,
+) {
+    Scaffold(
+        contentWindowInsets = WindowInsets.systemBars,
+        topBar = {
+            TopAppBar(
+                windowInsets = WindowInsets.statusBars,
+                backgroundColor = MaterialTheme.colors.surface,
+                navigationIcon = { AppBackButton() },
+                title = { Text("About API Key") },
+            )
+        },
+        content = { paddingValues ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp),
+            ) {
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // ── Hero card ──
+                Surface(
+                    shape = cardShape,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(20.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Surface(
+                            shape = CircleShape,
+                            color = MaterialTheme.colors.primary.copy(alpha = 0.1f),
+                            modifier = Modifier.size(56.dp),
+                        ) {
+                            Icon(
+                                Icons.Filled.Lock,
+                                contentDescription = null,
+                                tint = MaterialTheme.colors.primary,
+                                modifier = Modifier.padding(14.dp),
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = "What is an API Key?",
+                            style = MaterialTheme.typography.h6,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = "An API Key is like your personal pass to use 11labs services. " +
+                                "Think of it as an account credential that lets this app make " +
+                                "text-to-speech requests on your behalf.",
+                            style = MaterialTheme.typography.body2,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.65f),
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // ── Why card ──
+                Surface(
+                    shape = cardShape,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Row(
+                        modifier = Modifier.padding(16.dp),
+                        verticalAlignment = Alignment.Top,
+                    ) {
+                        Surface(
+                            shape = CircleShape,
+                            color = MaterialTheme.colors.primary.copy(alpha = 0.1f),
+                            modifier = Modifier.size(36.dp),
+                        ) {
+                            Icon(
+                                Icons.Outlined.HelpOutline,
+                                contentDescription = null,
+                                tint = MaterialTheme.colors.primary,
+                                modifier = Modifier.padding(8.dp),
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Why does this app need one?",
+                                style = MaterialTheme.typography.subtitle1,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = "This app does not include a built-in or shared API key. " +
+                                    "Each user needs their own key from 11labs to keep usage " +
+                                    "tied to your own account and quota.",
+                                style = MaterialTheme.typography.body2,
+                                color = MaterialTheme.colors.onSurface.copy(alpha = 0.65f),
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // ── Steps card ──
+                Surface(
+                    shape = cardShape,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "What you need to do",
+                            style = MaterialTheme.typography.subtitle1,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = "It only takes a minute, and you only need to do it once.",
+                            style = MaterialTheme.typography.body2,
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.55f),
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        StepItem(
+                            number = "1",
+                            title = "Create a free account",
+                            description = "Sign up at elevenlabs.io",
+                        )
+                        StepItem(
+                            number = "2",
+                            title = "Get your API key",
+                            description = "Find it under API Keys in your account settings",
+                        )
+                        StepItem(
+                            number = "3",
+                            title = "Paste it in Settings",
+                            description = "Open this app's Settings and fill in your key",
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // ── Links card ──
+                Surface(
+                    shape = cardShape,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Column(modifier = Modifier.padding(4.dp)) {
+                        LinkRow(
+                            icon = Icons.Filled.Key,
+                            label = "11labs API Keys page",
+                            onClick = { onOpenURL("https://elevenlabs.io/app/settings/api-keys") },
+                        )
+                        LinkRow(
+                            icon = Icons.Outlined.Info,
+                            label = "Visit 11labs official site",
+                            onClick = { onOpenURL("https://elevenlabs.io") },
+                        )
+                        LinkRow(
+                            icon = YoutubeLogo,
+                            label = "Watch tutorial on YouTube",
+                            tint = Color.Unspecified,
+                            onClick = { onOpenURL("https://www.youtube.com/results?search_query=elevenlabs+api+key+tutorial") },
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // ── CTA ──
+                Button(
+                    onClick = onGoToSettings,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        backgroundColor = MaterialTheme.colors.primary,
+                    ),
+                ) {
+                    Text(
+                        text = "Go to Settings",
+                        style = MaterialTheme.typography.button,
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        },
+    )
+}
+
+@Composable
+private fun StepItem(number: String, title: String, description: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colors.primary.copy(alpha = 0.1f),
+            modifier = Modifier.size(28.dp),
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = number,
+                    style = MaterialTheme.typography.caption,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colors.primary,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.body1,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onSurface.copy(alpha = 0.55f),
+            )
+        }
+    }
+}
+
+@Suppress("ObjectPropertyName")
+private var _youtubeLogo: ImageVector? = null
+private val YoutubeLogo: ImageVector
+    get() {
+        if (_youtubeLogo != null) return _youtubeLogo!!
+        _youtubeLogo = ImageVector.Builder(
+            name = "YoutubeLogo",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+        ).apply {
+            group(
+                pivotX = 12f,
+                pivotY = 12f,
+                scaleX = 0.84f,
+                scaleY = 0.84f,
+            ) {
+                path(fill = SolidColor(Color.Red)) {
+                    moveTo(23.5f, 6.2f)
+                    curveTo(23.2f, 5.1f, 22.4f, 4.3f, 21.3f, 4f)
+                    curveTo(19.4f, 3.5f, 12f, 3.5f, 12f, 3.5f)
+                    reflectiveCurveTo(4.6f, 3.5f, 2.7f, 4f)
+                    curveTo(1.6f, 4.3f, 0.8f, 5.1f, 0.5f, 6.2f)
+                    curveTo(0f, 8.1f, 0f, 12f, 0f, 12f)
+                    reflectiveCurveTo(0f, 15.9f, 0.5f, 17.8f)
+                    curveTo(0.8f, 18.9f, 1.6f, 19.7f, 2.7f, 20f)
+                    curveTo(4.6f, 20.5f, 12f, 20.5f, 12f, 20.5f)
+                    reflectiveCurveTo(19.4f, 20.5f, 21.3f, 20f)
+                    curveTo(22.4f, 19.7f, 23.2f, 18.9f, 23.5f, 17.8f)
+                    curveTo(24f, 15.9f, 24f, 12f, 24f, 12f)
+                    reflectiveCurveTo(24f, 8.1f, 23.5f, 6.2f)
+                    close()
+                }
+                path(fill = SolidColor(Color.White)) {
+                    moveTo(9.6f, 15.6f)
+                    verticalLineTo(8.4f)
+                    lineTo(15.9f, 12f)
+                    lineTo(9.6f, 15.6f)
+                    close()
+                }
+            }
+        }.build()
+        return _youtubeLogo!!
+    }
+
+@Composable
+private fun LinkRow(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    tint: Color = MaterialTheme.colors.onSurface.copy(alpha = 0.55f),
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+                tint = tint,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                label,
+                style = MaterialTheme.typography.body1,
+                color = MaterialTheme.colors.onSurface,
+                modifier = Modifier.weight(1f),
+            )
+            Icon(
+                Icons.Filled.OpenInNew,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colors.onSurface.copy(alpha = 0.35f),
+            )
+        }
+    }
+}

--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/setting/ApiKeyRequiredSheet.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/setting/ApiKeyRequiredSheet.kt
@@ -1,0 +1,116 @@
+package io.github.kkoshin.muse.feature.setting
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kotlin.math.roundToInt
+
+@Composable
+fun ApiKeyRequiredSheet(
+    onGoToSettings: () -> Unit,
+    onWhatIsApiKey: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val offsetY = remember { Animatable(1f) }
+
+    LaunchedEffect(Unit) {
+        offsetY.animateTo(0f, tween(300))
+    }
+
+    Dialog(
+        onDismissRequest = { onDismiss() },
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            // Scrim
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.4f * (1f - offsetY.value)))
+                    .clickable { onDismiss() },
+            )
+
+            // Sheet panel
+            Surface(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .offset { IntOffset(0, (offsetY.value * 1000).roundToInt()) }
+                    .navigationBarsPadding(),
+                shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+                elevation = 8.dp,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 24.dp, end = 24.dp, top = 32.dp, bottom = 20.dp),
+                ) {
+                    Text(
+                        text = "Setup needed to continue",
+                        style = MaterialTheme.typography.h6,
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Text(
+                        text = "This feature uses 11labs. You'll need to add your own API key in Settings before you can use it.",
+                        style = MaterialTheme.typography.body1,
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.7f),
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Button(
+                        onClick = onGoToSettings,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = MaterialTheme.colors.primary,
+                        ),
+                    ) {
+                        Text("Go to Settings")
+                    }
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    TextButton(
+                        onClick = onWhatIsApiKey,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            "What is API Key?",
+                            color = MaterialTheme.colors.onSurface.copy(alpha = 0.5f),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/setting/SettingScreen.kt
+++ b/muse/src/commonMain/kotlin/io/github/kkoshin/muse/feature/setting/SettingScreen.kt
@@ -1,11 +1,16 @@
 package io.github.kkoshin.muse.feature.setting
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -36,6 +41,7 @@ import io.github.kkoshin.muse.core.provider.CharacterQuota
 import io.github.kkoshin.muse.platformbridge.AppBackButton
 import io.github.kkoshin.muse.platformbridge.CURRENT_PLATFORM
 import io.github.kkoshin.muse.platformbridge.Platform
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import io.github.kkoshin.muse.Route
 import kotlinx.serialization.Serializable
@@ -47,10 +53,11 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
 @Serializable
-object SettingArgs : Route
+data class SettingArgs(val scrollToApiKey: Boolean = false) : Route
 
 @Composable
 fun SettingScreen(
+    args: SettingArgs,
     versionName: String,
     versionCode: Int,
     folderPath: String,
@@ -61,6 +68,7 @@ fun SettingScreen(
     val speechProcessorManager = koinInject<SpeechProcessorManager>()
     val accountManager = koinInject<AccountManager>()
     val scope = rememberCoroutineScope()
+    val listState = rememberLazyListState()
 
     var availableVoiceIds: Set<String>? by remember {
         mutableStateOf(null)
@@ -72,6 +80,16 @@ fun SettingScreen(
 
     val apiKeyValue: String? by accountManager.apiKey.collectAsState(null)
 
+    var highlightApiKey by remember { mutableStateOf(false) }
+    val highlightColor by animateColorAsState(
+        targetValue = if (highlightApiKey) {
+            MaterialTheme.colors.primary.copy(alpha = 0.1f)
+        } else {
+            Color.Transparent
+        },
+        animationSpec = tween(600),
+    )
+
     LaunchedEffect(apiKeyValue) {
         if (apiKeyValue.isNullOrEmpty()) return@LaunchedEffect
         accountManager.setElevenLabsApiKey(apiKeyValue!!)
@@ -79,6 +97,15 @@ fun SettingScreen(
         quota = speechProcessorManager.queryQuota().getOrNull()
         quota?.status?.let {
             accountManager.setSubscriptionStatus(it)
+        }
+    }
+
+    LaunchedEffect(args.scrollToApiKey) {
+        if (args.scrollToApiKey) {
+            listState.animateScrollToItem(0)
+            highlightApiKey = true
+            delay(1200)
+            highlightApiKey = false
         }
     }
 
@@ -99,6 +126,7 @@ fun SettingScreen(
         },
         content = { paddingValues ->
             LazyColumn(
+                state = listState,
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(paddingValues),
@@ -111,6 +139,7 @@ fun SettingScreen(
                 )
                 editTextPreference(
                     key = "api_key",
+                    modifier = Modifier.fillMaxWidth().background(highlightColor),
                     value = apiKeyValue ?: "",
                     onValueUpdate = { newValue ->
                         if (newValue.isNotEmpty()) {
@@ -139,7 +168,7 @@ fun SettingScreen(
                     inputLabel = "API Key",
                     widgetContainer = {
                         IconButton(onClick = {
-                            onOpenURL("https://elevenlabs.io/app/speech-synthesis/text-to-speech")
+                            onOpenURL("https://elevenlabs.io/app/developers/api-keys")
                         }) {
                             Icon(Icons.AutoMirrored.Filled.Launch, "launch")
                         }


### PR DESCRIPTION
Replace generic "apiKey is not set" toast with a bottom-sheet guide + help page + settings jump flow. Users now see a clear explanation and actionable next steps when triggering 11labs-dependent features without an API key configured.

- Add ApiKeyRequiredSheet: bottom-sheet with "Go to Settings" primary action and "What is API Key?" secondary link
- Add ApiKeyHelpScreen: guide page explaining API key concept, why the app needs one, and how to get one, with YouTube tutorial link
- Add AccountManager.apiKeyConfigured: Flow<Boolean> for convenience
- Add scroll-to-API-key-section + highlight animation in Settings when navigating from the guide flow
- Wire API key pre-check in EditorScreen, WhiteNoiseConfigScreen, and AudioIsolationScreen before 11labs-dependent operations